### PR TITLE
chore(package): add browser field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "author": "Christoph Guttandin",
+  "browser": "build/es5/bundle.js",
   "bugs": {
     "url": "https://github.com/chrisguttandin/worker-timers-worker/issues"
   },


### PR DESCRIPTION
This PR adds the `browser` field to `package.json` to prioritize the es5 build when using webpack with `web` target.